### PR TITLE
Allow flow imports

### DIFF
--- a/eslintrc-flow.json
+++ b/eslintrc-flow.json
@@ -12,7 +12,9 @@
      "flowtype/no-dupe-keys": 2,
      "flowtype/no-primitive-constructor-types": 2,
      "flowtype/object-type-delimiter": 2,
-     "flowtype/type-id-match": 2
+     "flowtype/type-id-match": 2,
+      "import/no-duplicate": 2,
+      "no-duplicate-imports": 0
   },
   "plugins": [
     "babel", "flowtype"

--- a/eslintrc-flow.json
+++ b/eslintrc-flow.json
@@ -8,11 +8,11 @@
       2,
       "always"
     ],
-     "flowtype/semi": 2,
-     "flowtype/no-dupe-keys": 2,
-     "flowtype/no-primitive-constructor-types": 2,
-     "flowtype/object-type-delimiter": 2,
-     "flowtype/type-id-match": 2,
+      "flowtype/semi": 2,
+      "flowtype/no-dupe-keys": 2,
+      "flowtype/no-primitive-constructor-types": 2,
+      "flowtype/object-type-delimiter": 2,
+      "flowtype/type-id-match": 2,
       "import/no-duplicate": 2,
       "no-duplicate-imports": 0
   },


### PR DESCRIPTION
By using [import/no-duplicates](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md) rather than the built-in `no-duplicate-imports` we can allow flow-imports.

Before this change the following would've been an error, but with this change is not

```js
import { foo } from 'bar';
import type { beep } from 'bar';
```